### PR TITLE
FInal timing fixes for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pg_ctl -D /usr/local/var/postgres start; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sleep 5; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then createuser -s postgres; fi
+  - sleep 15
   - npm install winston@2.3.0
   - npm install https://github.com/ioBroker/ioBroker.js-controller/tarball/master --production
 env:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,7 @@ test_script:
   - node --version
   - npm --version
   # give the DBs a chance to boot correctly
-  - ps: Start-Sleep -s 10
+  - ps: Start-Sleep -s 15
   # run tests
   - npm test
 

--- a/main.js
+++ b/main.js
@@ -1012,12 +1012,9 @@ function getId(id, type, cb) {
     clientPool.borrow(function (err, client) {
         if (err) {
             if (cb) cb(err);
-            adapter.log.debug('g1');
             return;
         }
-        adapter.log.debug('g2');
         client.execute(query, function (err, rows, fields) {
-            adapter.log.debug('g3');
             if (rows && rows.rows) rows = rows.rows;
             if (err) {
                 adapter.log.error('Cannot select ' + query + ': ' + err);
@@ -1026,9 +1023,7 @@ function getId(id, type, cb) {
                 return;
             }
             if (!rows.length) {
-                adapter.log.debug('g4');
                 if (type !== null) {
-                    adapter.log.debug('g5');
                     // insert
                     query = SQLFuncs.getIdInsert(adapter.config.dbname, id, type);
                     client.execute(query, function (err, rows, fields) {
@@ -1038,10 +1033,8 @@ function getId(id, type, cb) {
                             clientPool.return(client);
                             return;
                         }
-                        adapter.log.debug('g6');
                         query = SQLFuncs.getIdSelect(adapter.config.dbname,id);
                         client.execute(query, function (err, rows, fields) {
-                            adapter.log.debug('g7');
                             if (rows && rows.rows) rows = rows.rows;
                             if (err) {
                                 adapter.log.error('Cannot select ' + query + ': ' + err);
@@ -1052,13 +1045,11 @@ function getId(id, type, cb) {
                             sqlDPs[id].index = rows[0].id;
                             sqlDPs[id].type  = rows[0].type;
 
-                            adapter.log.debug('g8');
                             if (cb) cb();
                             clientPool.return(client);
                         });
                     });
                 } else {
-                    adapter.log.debug('g9');
                     if (cb) cb('id not found');
                     clientPool.return(client);
                 }
@@ -1066,7 +1057,6 @@ function getId(id, type, cb) {
                 sqlDPs[id].index = rows[0].id;
                 sqlDPs[id].type  = rows[0].type;
 
-                adapter.log.debug('g10');
                 if (cb) cb();
                 clientPool.return(client);
             }

--- a/main.js
+++ b/main.js
@@ -659,7 +659,10 @@ function pushHistory(id, state, timerRelog) {
     if (sqlDPs[id]) {
         var settings = sqlDPs[id][adapter.namespace];
 
-        if (!settings || !state) return;
+        if (!settings || !state) {
+            adapter.log.debug('1');
+            return;
+        }
 
         if (sqlDPs[id].relogTimeout) {
             clearTimeout(sqlDPs[id].relogTimeout);
@@ -702,13 +705,16 @@ function pushHistory(id, state, timerRelog) {
         } else {
             // only store state if really changed
             sqlDPs[id].state = state;
+            adapter.log.debug('2');
         }
         sqlDPs[id].lastLogTime = state.ts;
 
         // Do not store values ofter than 1 second
         if (!sqlDPs[id].timeout && settings.debounce) {
+            adapter.log.debug('3a');
             sqlDPs[id].timeout = setTimeout(pushHelper, settings.debounce, id);
         } else if (!settings.debounce) {
+            adapter.log.debug('3b');
             pushHelper(id);
         }
     }
@@ -745,10 +751,14 @@ function reLogHelper(_id) {
 }
 
 function pushHelper(_id) {
-    if (!sqlDPs[_id] || !sqlDPs[_id].state) return;
+    if (!sqlDPs[_id] || !sqlDPs[_id].state) {
+        adapter.log.debug('4');
+        return;
+    }
     var _settings = sqlDPs[_id][adapter.namespace];
     // if it was not deleted in this time
     if (_settings) {
+        adapter.log.debug('5');
         sqlDPs[_id].timeout = null;
 
         if (typeof sqlDPs[_id].state.val === 'string') {
@@ -870,12 +880,15 @@ function _insertValueIntoDB(query, id, cb) {
         if (err) {
             adapter.log.error(err);
             if (cb) cb();
+            adapter.log.debug('i1');
             return;
         }
         client.execute(query, function (err, rows, fields) {
             if (err) adapter.log.error('Cannot insert ' + query + ': ' + err);
             clientPool.return(client);
+            adapter.log.debug('i2');
             checkRetention(id);
+            adapter.log.debug('i3');
             if (cb) cb();
         });
     });
@@ -894,10 +907,12 @@ function pushValueIntoDB(id, state) {
     // get id if state
     if (sqlDPs[id].index === undefined) {
         // read or create in DB
+        adapter.log.debug('p1');
         return getId(id, type, function (err) {
             if (err) {
                 adapter.log.warn('Cannot get index of "' + id + '": ' + err);
             } else {
+                adapter.log.debug('p2');
                 pushValueIntoDB(id, state);
             }
         });
@@ -906,10 +921,12 @@ function pushValueIntoDB(id, state) {
     // get from
     if (state.from && !from[state.from]) {
         // read or create in DB
+        adapter.log.debug('p3');
         return getFrom(state.from, function (err) {
             if (err) {
                 adapter.log.warn('Cannot get "from" for "' + state.from + '": ' + err);
             } else {
+                adapter.log.debug('p4');
                 pushValueIntoDB(id, state);
             }
         });
@@ -947,6 +964,7 @@ function pushValueIntoDB(id, state) {
             processTasks();
         }
     } else {
+        adapter.log.debug('p5');
         _insertValueIntoDB(query, id);
     }
 }

--- a/main.js
+++ b/main.js
@@ -1012,9 +1012,12 @@ function getId(id, type, cb) {
     clientPool.borrow(function (err, client) {
         if (err) {
             if (cb) cb(err);
+            adapter.log.debug('g1');
             return;
         }
+        adapter.log.debug('g2');
         client.execute(query, function (err, rows, fields) {
+            adapter.log.debug('g3');
             if (rows && rows.rows) rows = rows.rows;
             if (err) {
                 adapter.log.error('Cannot select ' + query + ': ' + err);
@@ -1023,7 +1026,9 @@ function getId(id, type, cb) {
                 return;
             }
             if (!rows.length) {
+                adapter.log.debug('g4');
                 if (type !== null) {
+                    adapter.log.debug('g5');
                     // insert
                     query = SQLFuncs.getIdInsert(adapter.config.dbname, id, type);
                     client.execute(query, function (err, rows, fields) {
@@ -1033,8 +1038,10 @@ function getId(id, type, cb) {
                             clientPool.return(client);
                             return;
                         }
+                        adapter.log.debug('g6');
                         query = SQLFuncs.getIdSelect(adapter.config.dbname,id);
                         client.execute(query, function (err, rows, fields) {
+                            adapter.log.debug('g7');
                             if (rows && rows.rows) rows = rows.rows;
                             if (err) {
                                 adapter.log.error('Cannot select ' + query + ': ' + err);
@@ -1045,11 +1052,13 @@ function getId(id, type, cb) {
                             sqlDPs[id].index = rows[0].id;
                             sqlDPs[id].type  = rows[0].type;
 
+                            adapter.log.debug('g8');
                             if (cb) cb();
                             clientPool.return(client);
                         });
                     });
                 } else {
+                    adapter.log.debug('g9');
                     if (cb) cb('id not found');
                     clientPool.return(client);
                 }
@@ -1057,6 +1066,7 @@ function getId(id, type, cb) {
                 sqlDPs[id].index = rows[0].id;
                 sqlDPs[id].type  = rows[0].type;
 
+                adapter.log.debug('g10');
                 if (cb) cb();
                 clientPool.return(client);
             }

--- a/main.js
+++ b/main.js
@@ -659,10 +659,7 @@ function pushHistory(id, state, timerRelog) {
     if (sqlDPs[id]) {
         var settings = sqlDPs[id][adapter.namespace];
 
-        if (!settings || !state) {
-            adapter.log.debug('1');
-            return;
-        }
+        if (!settings || !state) return;
 
         if (sqlDPs[id].relogTimeout) {
             clearTimeout(sqlDPs[id].relogTimeout);
@@ -705,16 +702,13 @@ function pushHistory(id, state, timerRelog) {
         } else {
             // only store state if really changed
             sqlDPs[id].state = state;
-            adapter.log.debug('2');
         }
         sqlDPs[id].lastLogTime = state.ts;
 
         // Do not store values ofter than 1 second
         if (!sqlDPs[id].timeout && settings.debounce) {
-            adapter.log.debug('3a');
             sqlDPs[id].timeout = setTimeout(pushHelper, settings.debounce, id);
         } else if (!settings.debounce) {
-            adapter.log.debug('3b');
             pushHelper(id);
         }
     }
@@ -751,14 +745,10 @@ function reLogHelper(_id) {
 }
 
 function pushHelper(_id) {
-    if (!sqlDPs[_id] || !sqlDPs[_id].state) {
-        adapter.log.debug('4');
-        return;
-    }
+    if (!sqlDPs[_id] || !sqlDPs[_id].state) return;
     var _settings = sqlDPs[_id][adapter.namespace];
     // if it was not deleted in this time
     if (_settings) {
-        adapter.log.debug('5');
         sqlDPs[_id].timeout = null;
 
         if (typeof sqlDPs[_id].state.val === 'string') {
@@ -880,15 +870,12 @@ function _insertValueIntoDB(query, id, cb) {
         if (err) {
             adapter.log.error(err);
             if (cb) cb();
-            adapter.log.debug('i1');
             return;
         }
         client.execute(query, function (err, rows, fields) {
             if (err) adapter.log.error('Cannot insert ' + query + ': ' + err);
             clientPool.return(client);
-            adapter.log.debug('i2');
             checkRetention(id);
-            adapter.log.debug('i3');
             if (cb) cb();
         });
     });
@@ -907,12 +894,10 @@ function pushValueIntoDB(id, state) {
     // get id if state
     if (sqlDPs[id].index === undefined) {
         // read or create in DB
-        adapter.log.debug('p1');
         return getId(id, type, function (err) {
             if (err) {
                 adapter.log.warn('Cannot get index of "' + id + '": ' + err);
             } else {
-                adapter.log.debug('p2');
                 pushValueIntoDB(id, state);
             }
         });
@@ -921,12 +906,10 @@ function pushValueIntoDB(id, state) {
     // get from
     if (state.from && !from[state.from]) {
         // read or create in DB
-        adapter.log.debug('p3');
         return getFrom(state.from, function (err) {
             if (err) {
                 adapter.log.warn('Cannot get "from" for "' + state.from + '": ' + err);
             } else {
-                adapter.log.debug('p4');
                 pushValueIntoDB(id, state);
             }
         });
@@ -964,7 +947,6 @@ function pushValueIntoDB(id, state) {
             processTasks();
         }
     } else {
-        adapter.log.debug('p5');
         _insertValueIntoDB(query, id);
     }
 }

--- a/test/testMSSQL.js
+++ b/test/testMSSQL.js
@@ -134,7 +134,7 @@ describe('Test MSSQL', function() {
                         // wait till adapter receives the new settings
                         setTimeout(function () {
                             done();
-                        }, 2000);
+                        }, 10000);
                     });
 /*                    objects.getObject('system.adapter.sql.0.memRss', function (err, obj) {
                         obj.common.custom = {

--- a/test/testMSSQL.js
+++ b/test/testMSSQL.js
@@ -136,7 +136,7 @@ describe('Test MSSQL', function() {
                         // wait till adapter receives the new settings
                         setTimeout(function () {
                             done();
-                        }, 2000);
+                        }, 10000);
                     });
 /*                    objects.getObject('system.adapter.sql.0.memRss', function (err, obj) {
                         obj.common.custom = {

--- a/test/testMSSQL.js
+++ b/test/testMSSQL.js
@@ -134,7 +134,7 @@ describe('Test MSSQL', function() {
                         // wait till adapter receives the new settings
                         setTimeout(function () {
                             done();
-                        }, 10000);
+                        }, 1000);
                     });
 /*                    objects.getObject('system.adapter.sql.0.memRss', function (err, obj) {
                         obj.common.custom = {
@@ -206,7 +206,7 @@ describe('Test MSSQL', function() {
                                                     if (err) {
                                                         console.log(err);
                                                     }
-                                                    done();
+                                                    setTimeout(done, 5000);
                                                 });
                                             }, 100);
                                         });

--- a/test/testMSSQL.js
+++ b/test/testMSSQL.js
@@ -9,6 +9,8 @@ var sendToID = 1;
 
 var adapterShortName = setup.adapterName.substring(setup.adapterName.indexOf('.')+1);
 
+var now = new Date().getTime();
+
 function checkConnectionOfAdapter(cb, counter) {
     counter = counter || 0;
     if (counter > 20) {
@@ -175,7 +177,6 @@ describe('Test MSSQL', function() {
             done();
             return;
         }
-        var now = new Date().getTime();
 
         states.setState('system.adapter.sql.0.memRss', {val: 1, ts: now - 20000}, function (err) {
             if (err) {
@@ -252,8 +253,7 @@ describe('Test MSSQL', function() {
         sendTo('sql.0', 'getHistory', {
             id: 'system.adapter.sql.0.memRss',
             options: {
-                start:     new Date().getTime() - 30000,
-                end:       new Date().getTime(),
+                start:     now - 30000,
                 limit:     50,
                 count:     50,
                 aggregate: 'none'
@@ -270,8 +270,8 @@ describe('Test MSSQL', function() {
             sendTo('sql.0', 'getHistory', {
                 id: 'system.adapter.sql.0.memRss',
                 options: {
-                    start:     new Date().getTime() - 15000,
-                    end:       new Date().getTime(),
+                    start:     now - 15000,
+                    end:       now,
                     limit:     2,
                     count:     2,
                     aggregate: 'none'

--- a/test/testMSSQL.js
+++ b/test/testMSSQL.js
@@ -134,7 +134,7 @@ describe('Test MSSQL', function() {
                         // wait till adapter receives the new settings
                         setTimeout(function () {
                             done();
-                        }, 1000);
+                        }, 2000);
                     });
 /*                    objects.getObject('system.adapter.sql.0.memRss', function (err, obj) {
                         obj.common.custom = {

--- a/test/testMySQL.js
+++ b/test/testMySQL.js
@@ -188,7 +188,7 @@ describe('Test MySQL', function() {
                                                     if (err) {
                                                         console.log(err);
                                                     }
-                                                    done();
+                                                    setTimeout(done, 5000);
                                                 });
                                             }, 100);
                                         });

--- a/test/testMySQL.js
+++ b/test/testMySQL.js
@@ -124,7 +124,7 @@ describe('Test MySQL', function() {
                         // wait till adapter receives the new settings
                         setTimeout(function () {
                             done();
-                        }, 10000);
+                        }, 2000);
                     });
 /*                    objects.getObject('system.adapter.sql.0.memRss', function (err, obj) {
                         obj.common.custom = {

--- a/test/testMySQL.js
+++ b/test/testMySQL.js
@@ -126,7 +126,7 @@ describe('Test MySQL', function() {
                         // wait till adapter receives the new settings
                         setTimeout(function () {
                             done();
-                        }, 2000);
+                        }, 10000);
                     });
 /*                    objects.getObject('system.adapter.sql.0.memRss', function (err, obj) {
                         obj.common.custom = {

--- a/test/testMySQL.js
+++ b/test/testMySQL.js
@@ -9,6 +9,8 @@ var sendToID = 1;
 
 var adapterShortName = setup.adapterName.substring(setup.adapterName.indexOf('.')+1);
 
+var now = new Date().getTime();
+
 function checkConnectionOfAdapter(cb, counter) {
     counter = counter || 0;
     if (counter > 20) {
@@ -157,7 +159,6 @@ describe('Test MySQL', function() {
     });
     it('Test MySQL: Write values into DB', function (done) {
         this.timeout(10000);
-        var now = new Date().getTime();
 
         states.setState('system.adapter.sql.0.memRss', {val: 1, ts: now - 20000}, function (err) {
             if (err) {
@@ -227,7 +228,7 @@ describe('Test MySQL', function() {
         sendTo('sql.0', 'getHistory', {
             id: 'system.adapter.sql.0.memRss',
             options: {
-                start:     new Date().getTime() - 30000,
+                start:     now - 30000,
                 limit:     50,
                 count:     50,
                 aggregate: 'none'
@@ -244,8 +245,8 @@ describe('Test MySQL', function() {
             sendTo('sql.0', 'getHistory', {
                 id: 'system.adapter.sql.0.memRss',
                 options: {
-                    start:     new Date().getTime() - 15000,
-                    end:       new Date().getTime(),
+                    start:     now - 15000,
+                    end:       now,
                     limit:     2,
                     count:     2,
                     aggregate: 'none'

--- a/test/testMySQL.js
+++ b/test/testMySQL.js
@@ -124,7 +124,7 @@ describe('Test MySQL', function() {
                         // wait till adapter receives the new settings
                         setTimeout(function () {
                             done();
-                        }, 2000);
+                        }, 10000);
                     });
 /*                    objects.getObject('system.adapter.sql.0.memRss', function (err, obj) {
                         obj.common.custom = {

--- a/test/testMySQL2.js
+++ b/test/testMySQL2.js
@@ -125,7 +125,7 @@ describe('Test MySQL-with-dash', function() {
                         // wait till adapter receives the new settings
                         setTimeout(function () {
                             done();
-                        }, 10000);
+                        }, 1000);
                     });
 /*                    objects.getObject('system.adapter.sql.0.memRss', function (err, obj) {
                         obj.common.custom = {
@@ -189,7 +189,7 @@ describe('Test MySQL-with-dash', function() {
                                                     if (err) {
                                                         console.log(err);
                                                     }
-                                                    done();
+                                                    setTimeout(done, 5000);
                                                 });
                                             }, 100);
                                         });

--- a/test/testMySQL2.js
+++ b/test/testMySQL2.js
@@ -9,6 +9,8 @@ var sendToID = 1;
 
 var adapterShortName = setup.adapterName.substring(setup.adapterName.indexOf('.')+1);
 
+var now = new Date().getTime();
+
 function checkConnectionOfAdapter(cb, counter) {
     counter = counter || 0;
     if (counter > 20) {
@@ -158,7 +160,6 @@ describe('Test MySQL-with-dash', function() {
     });
     it('Test MySQL-with-dash: Write values into DB', function (done) {
         this.timeout(10000);
-        var now = new Date().getTime();
 
         states.setState('system.adapter.sql.0.memRss', {val: 1, ts: now - 20000}, function (err) {
             if (err) {
@@ -228,8 +229,7 @@ describe('Test MySQL-with-dash', function() {
         sendTo('sql.0', 'getHistory', {
             id: 'system.adapter.sql.0.memRss',
             options: {
-                start:     new Date().getTime() - 30000,
-                end:       new Date().getTime(),
+                start:     now - 30000,
                 limit:     50,
                 count:     50,
                 aggregate: 'none'
@@ -246,8 +246,8 @@ describe('Test MySQL-with-dash', function() {
             sendTo('sql.0', 'getHistory', {
                 id: 'system.adapter.sql.0.memRss',
                 options: {
-                    start:     new Date().getTime() - 15000,
-                    end:       new Date().getTime(),
+                    start:     now - 15000,
+                    end:       now,
                     limit:     2,
                     count:     2,
                     aggregate: 'none'

--- a/test/testMySQL2.js
+++ b/test/testMySQL2.js
@@ -127,7 +127,7 @@ describe('Test MySQL-with-dash', function() {
                         // wait till adapter receives the new settings
                         setTimeout(function () {
                             done();
-                        }, 2000);
+                        }, 10000);
                     });
 /*                    objects.getObject('system.adapter.sql.0.memRss', function (err, obj) {
                         obj.common.custom = {

--- a/test/testMySQL2.js
+++ b/test/testMySQL2.js
@@ -125,7 +125,7 @@ describe('Test MySQL-with-dash', function() {
                         // wait till adapter receives the new settings
                         setTimeout(function () {
                             done();
-                        }, 1000);
+                        }, 2000);
                     });
 /*                    objects.getObject('system.adapter.sql.0.memRss', function (err, obj) {
                         obj.common.custom = {

--- a/test/testMySQL2.js
+++ b/test/testMySQL2.js
@@ -125,7 +125,7 @@ describe('Test MySQL-with-dash', function() {
                         // wait till adapter receives the new settings
                         setTimeout(function () {
                             done();
-                        }, 2000);
+                        }, 10000);
                     });
 /*                    objects.getObject('system.adapter.sql.0.memRss', function (err, obj) {
                         obj.common.custom = {

--- a/test/testPostgreSQL.js
+++ b/test/testPostgreSQL.js
@@ -9,6 +9,8 @@ var sendToID = 1;
 
 var adapterShortName = setup.adapterName.substring(setup.adapterName.indexOf('.')+1);
 
+var now = new Date().getTime();
+
 function checkConnectionOfAdapter(cb, counter) {
     counter = counter || 0;
     if (counter > 20) {
@@ -157,7 +159,6 @@ describe('Test PostgreSQL', function() {
     });
     it('Test PostgreSQL: Write values into DB', function (done) {
         this.timeout(10000);
-        var now = new Date().getTime();
 
         states.setState('system.adapter.sql.0.memRss', {val: 1, ts: now - 20000}, function (err) {
             if (err) {
@@ -226,8 +227,7 @@ describe('Test PostgreSQL', function() {
         sendTo('sql.0', 'getHistory', {
             id: 'system.adapter.sql.0.memRss',
             options: {
-                start:     new Date().getTime() - 30000,
-                end:       new Date().getTime(),
+                start:     now - 30000,
                 limit:     50,
                 count:     50,
                 aggregate: 'none'
@@ -244,8 +244,8 @@ describe('Test PostgreSQL', function() {
             sendTo('sql.0', 'getHistory', {
                 id: 'system.adapter.sql.0.memRss',
                 options: {
-                    start:     new Date().getTime() - 15000,
-                    end:       new Date().getTime(),
+                    start:     now - 15000,
+                    end:       now,
                     limit:     2,
                     count:     2,
                     aggregate: 'none'

--- a/test/testPostgreSQL.js
+++ b/test/testPostgreSQL.js
@@ -126,7 +126,7 @@ describe('Test PostgreSQL', function() {
                         // wait till adapter receives the new settings
                         setTimeout(function () {
                             done();
-                        }, 2000);
+                        }, 10000);
                     });
 /*                    objects.getObject('system.adapter.sql.0.memRss', function (err, obj) {
                         obj.common.custom = {

--- a/test/testPostgreSQL.js
+++ b/test/testPostgreSQL.js
@@ -124,7 +124,7 @@ describe('Test PostgreSQL', function() {
                         // wait till adapter receives the new settings
                         setTimeout(function () {
                             done();
-                        }, 2000);
+                        }, 10000);
                     });
 /*                    objects.getObject('system.adapter.sql.0.memRss', function (err, obj) {
                         obj.common.custom = {

--- a/test/testPostgreSQL.js
+++ b/test/testPostgreSQL.js
@@ -124,7 +124,7 @@ describe('Test PostgreSQL', function() {
                         // wait till adapter receives the new settings
                         setTimeout(function () {
                             done();
-                        }, 10000);
+                        }, 1000);
                     });
 /*                    objects.getObject('system.adapter.sql.0.memRss', function (err, obj) {
                         obj.common.custom = {
@@ -188,7 +188,7 @@ describe('Test PostgreSQL', function() {
                                                     if (err) {
                                                         console.log(err);
                                                     }
-                                                    setTimeout(done, 1000);
+                                                    setTimeout(done, 5000);
                                                 });
                                             }, 200);
                                         });

--- a/test/testPostgreSQL.js
+++ b/test/testPostgreSQL.js
@@ -124,7 +124,7 @@ describe('Test PostgreSQL', function() {
                         // wait till adapter receives the new settings
                         setTimeout(function () {
                             done();
-                        }, 1000);
+                        }, 2000);
                     });
 /*                    objects.getObject('system.adapter.sql.0.memRss', function (err, obj) {
                         obj.common.custom = {

--- a/test/testSQLite.js
+++ b/test/testSQLite.js
@@ -9,6 +9,8 @@ var sendToID = 1;
 
 var adapterShortName = setup.adapterName.substring(setup.adapterName.indexOf('.')+1);
 
+var now = new Date().getTime();
+
 function checkConnectionOfAdapter(cb, counter) {
     counter = counter || 0;
     if (counter > 20) {
@@ -153,7 +155,6 @@ describe('Test SQLite', function() {
     });
     it('Test SQLite: Write values into DB', function (done) {
         this.timeout(10000);
-        var now = new Date().getTime();
 
         states.setState('system.adapter.sql.0.memRss', {val: 1, ts: now - 20000}, function (err) {
             if (err) {
@@ -222,8 +223,7 @@ describe('Test SQLite', function() {
         sendTo('sql.0', 'getHistory', {
             id: 'system.adapter.sql.0.memRss',
             options: {
-                start:     new Date().getTime() - 30000,
-                end:       new Date().getTime(),
+                start:     now - 30000,
                 limit:     50,
                 count:     50,
                 aggregate: 'none'
@@ -240,8 +240,8 @@ describe('Test SQLite', function() {
             sendTo('sql.0', 'getHistory', {
                 id: 'system.adapter.sql.0.memRss',
                 options: {
-                    start:     new Date().getTime() - 15000,
-                    end:       new Date().getTime(),
+                    start:     now - 15000,
+                    end:       now,
                     limit:     2,
                     count:     2,
                     aggregate: 'none'

--- a/test/testSQLite.js
+++ b/test/testSQLite.js
@@ -184,9 +184,9 @@ describe('Test SQLite', function() {
                                                     if (err) {
                                                         console.log(err);
                                                     }
-                                                    done();
+                                                    setTimeout(done, 5000);
                                                 });
-                                            }, 2000);
+                                            }, 1000);
                                         });
                                     }, 1000);
                                 });

--- a/test/testSQLite.js
+++ b/test/testSQLite.js
@@ -120,7 +120,7 @@ describe('Test SQLite', function() {
                         // wait till adapter receives the new settings
                         setTimeout(function () {
                             done();
-                        }, 2000);
+                        }, 10000);
                     });
 /*                    objects.getObject('system.adapter.sql.0.memRss', function (err, obj) {
                         obj.common.custom = {


### PR DESCRIPTION
… reason is that sometimes DB needs time to initialize but „connect“
runs in parallel to pot. first value logging. Because of this sometimes the values were tried to being written before tables were created