### PR TITLE
fixes issues when importing data from history

### DIFF
--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -56,11 +56,11 @@ exports.insert = function (dbname, index, values) {
     for (let db in insertValues) {
         if (db === 'ts_counter') {
             while (insertValues[db].length) {
-                query += `INSERT IGNORE INTO \`${dbname}\`.ts_counter (id, ts, val) VALUES ${insertValues[db].splice(0, 500).join(',')};\n`;
+                query += `INSERT IGNORE INTO \`${dbname}\`.ts_counter (id, ts, val) VALUES ${insertValues[db].splice(0, 1000).join(',')};\n`;
             }
         } else {
             while (insertValues[db].length) {
-                query += `INSERT IGNORE INTO \`${dbname}\`.${db} (id, ts, val, ack, _from, q) VALUES ${insertValues[db].splice(0, 500).join(',')};\n`;
+                query += `INSERT IGNORE INTO \`${dbname}\`.${db} (id, ts, val, ack, _from, q) VALUES ${insertValues[db].splice(0, 1000).join(',')};\n`;
             }
         }
     }

--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -56,11 +56,11 @@ exports.insert = function (dbname, index, values) {
     for (let db in insertValues) {
         if (db === 'ts_counter') {
             while (insertValues[db].length) {
-                query += `INSERT IGNORE INTO \`${dbname}\`.ts_counter (id, ts, val) VALUES ${insertValues[db].splice(0, 500).join(',')};`;
+                query += `INSERT IGNORE INTO \`${dbname}\`.ts_counter (id, ts, val) VALUES ${insertValues[db].splice(0, 500).join(',')};\n`;
             }
         } else {
             while (insertValues[db].length) {
-                query += `INSERT IGNORE INTO \`${dbname}\`.${db} (id, ts, val, ack, _from, q) VALUES ${insertValues[db].splice(0, 500).join(',')};`;
+                query += `INSERT IGNORE INTO \`${dbname}\`.${db} (id, ts, val, ack, _from, q) VALUES ${insertValues[db].splice(0, 500).join(',')};\n`;
             }
         }
     }
@@ -92,7 +92,7 @@ exports.getIdInsert = function (dbname, name, type) {
 };
 
 exports.getIdUpdate = function (dbname, id, type) {
-    return  `UPDATE \`${dbname}\`.datapoints SET type=${type} WHERE id=${id};`;
+    return  `UPDATE IGNORE \`${dbname}\`.datapoints SET type=${type} WHERE id=${id};`;
 };
 
 exports.getFromSelect = function (dbname, from) {

--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -56,11 +56,11 @@ exports.insert = function (dbname, index, values) {
     for (let db in insertValues) {
         if (db === 'ts_counter') {
             while (insertValues[db].length) {
-                query += `INSERT INTO \`${dbname}\`.ts_counter (id, ts, val) VALUES ${insertValues[db].splice(0, 500).join(',')};`;
+                query += `INSERT IGNORE INTO \`${dbname}\`.ts_counter (id, ts, val) VALUES ${insertValues[db].splice(0, 500).join(',')};`;
             }
         } else {
             while (insertValues[db].length) {
-                query += `INSERT INTO \`${dbname}\`.${db} (id, ts, val, ack, _from, q) VALUES ${insertValues[db].splice(0, 500).join(',')};`;
+                query += `INSERT IGNORE INTO \`${dbname}\`.${db} (id, ts, val, ack, _from, q) VALUES ${insertValues[db].splice(0, 500).join(',')};`;
             }
         }
     }
@@ -88,7 +88,7 @@ exports.getIdSelect = function (dbname, name) {
 };
 
 exports.getIdInsert = function (dbname, name, type) {
-    return  `INSERT INTO \`${dbname}\`.datapoints (name, type) VALUES('${name}', ${type});`;
+    return  `INSERT IGNORE INTO \`${dbname}\`.datapoints (name, type) VALUES('${name}', ${type});`;
 };
 
 exports.getIdUpdate = function (dbname, id, type) {
@@ -104,7 +104,7 @@ exports.getFromSelect = function (dbname, from) {
 };
 
 exports.getFromInsert = function (dbname, from) {
-    return `INSERT INTO \`${dbname}\`.sources (name) VALUES('${from}');`;
+    return `INSERT IGNORE INTO \`${dbname}\`.sources (name) VALUES('${from}');`;
 };
 
 exports.getCounterDiff = function (dbname, options) {

--- a/main.js
+++ b/main.js
@@ -1872,7 +1872,7 @@ function pushValuesIntoDB(id, list, cb) {
             adapter.log.error(error);
             cb && cb(error);
         } else {
-            tasks.push({operation: 'insert ignore', index: sqlDPs[id].index, list, id, callback: cb});
+            tasks.push({operation: 'insert', index: sqlDPs[id].index, list, id, callback: cb});
             tasks.length === 1 && processTasks();
         }
     } else {

--- a/main.js
+++ b/main.js
@@ -1872,7 +1872,7 @@ function pushValuesIntoDB(id, list, cb) {
             adapter.log.error(error);
             cb && cb(error);
         } else {
-            tasks.push({operation: 'insert', index: sqlDPs[id].index, list, id, callback: cb});
+            tasks.push({operation: 'insert ignore', index: sqlDPs[id].index, list, id, callback: cb});
             tasks.length === 1 && processTasks();
         }
     } else {


### PR DESCRIPTION
fixes issues when importing data from history to sql:
- use "insert ignore" and "update ignore" to prevent duplicate key issues
- workaround multiline insert issue (allowing 1000 lines to be inserted at once) 