### PR TITLE
Issue 273 ignore blockTime + changesMinDelta if val === 0

### DIFF
--- a/main.js
+++ b/main.js
@@ -1180,7 +1180,7 @@ function pushHistory(id, state, timerRelog) {
                 sqlDPs[id].timeout = null;
             }
 
-            if (!valueUnstable && settings.blockTime && sqlDPs[id].state && (sqlDPs[id].state.ts + settings.blockTime) > state.ts) {
+            if (!valueUnstable && settings.blockTime && sqlDPs[id].state && (sqlDPs[id].state.ts + settings.blockTime) > state.ts && state.val !== 0) {
                 settings.enableDebugLogs && adapter.log.debug(`value ignored blockTime ${id}, value=${state.val}, ts=${state.ts}, lastState.ts=${sqlDPs[id].state.ts}, blockTime=${settings.blockTime}`);
                 return;
             }
@@ -1226,7 +1226,8 @@ function pushHistory(id, state, timerRelog) {
                     if (
                         sqlDPs[id].state.val !== null &&
                         settings.changesMinDelta !== 0 &&
-                        Math.abs(sqlDPs[id].state.val - state.val) < settings.changesMinDelta
+                        Math.abs(sqlDPs[id].state.val - state.val) < settings.changesMinDelta  &&
+						state.val !== 0
                     ) {
                         if (!valueUnstable && !settings.disableSkippedValueLogging) {
                             sqlDPs[id].skipped = state;


### PR DESCRIPTION
See Issue https://github.com/ioBroker/ioBroker.sql/issues/273

Small quick fix: always log values if value === 0.

Solves problem, that if you log electric power of a solar penal or power of an electric meter of a wallbox, the last value that is logged is often not 0 W. That is because the last value is e.g. 500 W and then 5 seconds later it is 0 W. If you have enabled a blockTime of 20 sec, the last logged value is always 500W instead of 0W. This is confusing in diagrams.

Maybe there's a better solution or this new behavior should be activated with an extra check box?